### PR TITLE
Simplify validation checking and fix naming

### DIFF
--- a/src/page/auth/login.js
+++ b/src/page/auth/login.js
@@ -31,14 +31,8 @@ const Login = () => {
     dispatch(loginAction(username, password));
   };
 
-  const validateInput = () => {
-    const usernameWithoutSpace = username.trim();
-    const passwordWithoutSpace = password.trim();
-    if (usernameWithoutSpace !== "" && passwordWithoutSpace !== "") {
-      return false;
-    }
-    return true;
-  };
+  const isInputValid = username.trim() !== "" && password.trim() !== "";
+
 
   return (
     <form
@@ -79,7 +73,7 @@ const Login = () => {
         variant="contained"
         color="secondary"
         type="submit"
-        disabled={validateInput()}
+        disabled={isInputValid}
       >
         {t("auth.login")}
       </Button>

--- a/src/page/auth/register.js
+++ b/src/page/auth/register.js
@@ -3,7 +3,7 @@ import { TextField, Button } from "@material-ui/core";
 import Alert from "@material-ui/lab/Alert";
 import { useSelector, useDispatch } from "react-redux";
 import { registerUserAction, showAuthErrorBox } from "../../redux/actions/auth";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next"
 
 const EMAIL_REGEXP = new RegExp("^\\w+@([a-z]+\\.)+[a-z]{2,4}$");
 

--- a/src/page/auth/register.js
+++ b/src/page/auth/register.js
@@ -3,7 +3,10 @@ import { TextField, Button } from "@material-ui/core";
 import Alert from "@material-ui/lab/Alert";
 import { useSelector, useDispatch } from "react-redux";
 import { registerUserAction, showAuthErrorBox } from "../../redux/actions/auth";
-import { useTranslation } from "react-i18next"
+import { useTranslation } from "react-i18next";
+
+const EMAIL_REGEXP = new RegExp("^\\w+@([a-z]+\\.)+[a-z]{2,4}$");
+
 const Register = () => {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
@@ -28,18 +31,10 @@ const Register = () => {
     dispatch(registerUserAction(username, email, password));
   };
 
-
-  const validateInput = () => {
-    const usernameWithoutSpace = username.trim();
-    const passwordWithoutSpace = password.trim();
-    const emailWithoutSpace = email.trim();
-    const emailFormat = new RegExp("^\\w+@([a-z]+\\.)+[a-z]{2,4}$");
-    const isEmailFormatCorrect = emailFormat.test(emailWithoutSpace);
-    if(usernameWithoutSpace !== "" && passwordWithoutSpace !== "" && emailWithoutSpace !== "" && isEmailFormatCorrect === true){
-      return false;
-    }
-    return true;
-  }
+  const isInputValid =
+    username.trim() !== "" &&
+    password.trim() !== "" &&
+    EMAIL_REGEXP.test(email.trim());
 
   return (
     <form
@@ -88,7 +83,12 @@ const Register = () => {
       </div>
       <br />
       <br />
-      <Button variant="contained" color="secondary" type="submit" disabled={validateInput()}>
+      <Button
+        variant="contained"
+        color="secondary"
+        type="submit"
+        disabled={isInputValid}
+      >
         {t("auth.signUp")}
       </Button>
     </form>


### PR DESCRIPTION
1. When a function return a boolean, usually we name it start with `is`. Otherwise a function with only a verb as name will make people think it is just performing some action without return.

2. Usually calling a function in return is used when we have some reused logic to generate different content. For example
```js
const getNameTitle = (gender, name) => { 
  const genderPrefix = gender === 'male' ? 'Mr.' : 'Miss';
  return <h5>{`${genderPrefix}${name}`}</h5>
}
```
(or if it has some heavy calculation which should not be called when not rendered, you should consider useMemo, but anyways not in this case)

If the function is called **only once** and called in every render, you can simply declare the boolean without function.

3. constant strings, numbers, regexp can be put outside the component because they are really constant. We can further put them in separate helper files to improve reusability.